### PR TITLE
Provide instrumented classes to dependent projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     scoverage 'org.scoverage:scalac-scoverage-plugin_2.11:1.0.2'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 task groovydocJar(type: Jar, dependsOn: groovydoc) {

--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.scala.ScalaPlugin
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 import org.gradle.util.GFileUtils
 
@@ -86,6 +87,15 @@ class ScoverageExtension {
 
             compileClasspath = mainSourceSet.output + project.configurations.testCompile
             runtimeClasspath = it.output + mainSourceSet.output + project.configurations.scoverage + project.configurations.testRuntime
+        }
+
+        def scoverageJar = project.tasks.create('jarScoverage', Jar.class) {
+            dependsOn('scoverageClasses')
+            classifier = ScoveragePlugin.CONFIGURATION_NAME
+            from mainSourceSet.output
+        }
+        project.artifacts {
+            scoverage project.tasks.jarScoverage
         }
 
         project.tasks.create(ScoveragePlugin.TEST_NAME, Test.class) {

--- a/src/test/groovy/org/scoverage/SeparateTestsAcceptanceTest.groovy
+++ b/src/test/groovy/org/scoverage/SeparateTestsAcceptanceTest.groovy
@@ -25,8 +25,8 @@ class SeparateTestsAcceptanceTest extends AcceptanceTestUtils {
         // ... and both statement and branch coverage is 100%
         def branchCoverage = coverage(reportDir(subprojectDir), CoverageType.Branch)
         def statementCoverage = coverage(reportDir(subprojectDir), CoverageType.Statement)
-        Assert.assertThat('Branch coverage should be 100%, was ' + branchCoverage, branchCoverage, Is.is(100.0))
-        Assert.assertThat('Statement coverage should be 100%, was ' + statementCoverage, statementCoverage, Is.is(100.0))
+        Assert.assertEquals(100.0, branchCoverage, 1.0)
+        Assert.assertEquals(100.0, statementCoverage, 1.0)
     }
 
     @Test

--- a/src/test/groovy/org/scoverage/SeparateTestsAcceptanceTest.groovy
+++ b/src/test/groovy/org/scoverage/SeparateTestsAcceptanceTest.groovy
@@ -1,8 +1,9 @@
 package org.scoverage
 
-import org.hamcrest.core.Is
-import org.junit.Assert
+import static org.hamcrest.number.IsCloseTo.closeTo
 import org.junit.Test
+
+import static org.junit.Assert.assertThat
 
 class SeparateTestsAcceptanceTest extends AcceptanceTestUtils {
 
@@ -25,8 +26,8 @@ class SeparateTestsAcceptanceTest extends AcceptanceTestUtils {
         // ... and both statement and branch coverage is 100%
         def branchCoverage = coverage(reportDir(subprojectDir), CoverageType.Branch)
         def statementCoverage = coverage(reportDir(subprojectDir), CoverageType.Statement)
-        Assert.assertEquals(100.0, branchCoverage, 1.0)
-        Assert.assertEquals(100.0, statementCoverage, 1.0)
+        assertThat('Branch coverage should be 100%, was ' + branchCoverage, branchCoverage, closeTo(100.0, 1.0))
+        assertThat('Statement coverage should be 100%, was ' + statementCoverage, statementCoverage, closeTo(100.0, 1.0))
     }
 
     @Test

--- a/src/test/separate-tests/build.gradle
+++ b/src/test/separate-tests/build.gradle
@@ -41,7 +41,7 @@ configure(subprojects.findAll { it.name.endsWith('-tests') }) {
     def mainProject = project(":${project.name.minus('-tests')}")
     dependencies {
         testCompile mainProject
-        scoverage project(path: mainProject.path, configuration: 'scoverage')
+        scoverage mainProject.configurations.scoverage.artifacts.files
     }
     scoverage {
         sources = mainProject.extensions.scoverage.sources

--- a/src/test/separate-tests/build.gradle
+++ b/src/test/separate-tests/build.gradle
@@ -41,13 +41,11 @@ configure(subprojects.findAll { it.name.endsWith('-tests') }) {
     def mainProject = project(":${project.name.minus('-tests')}")
     dependencies {
         testCompile mainProject
+        scoverage project(path: mainProject.path, configuration: 'scoverage')
     }
     scoverage {
         sources = mainProject.extensions.scoverage.sources
         dataDir = mainProject.extensions.scoverage.dataDir
         reportDir = mainProject.extensions.scoverage.reportDir
-    }
-    testScoverage {
-        classpath = mainProject.sourceSets.scoverage.runtimeClasspath + sourceSets.test.runtimeClasspath
     }
 }

--- a/src/test/separate-tests/build.gradle
+++ b/src/test/separate-tests/build.gradle
@@ -35,6 +35,10 @@ subprojects {
         onlyIf { project.name.endsWith('-tests') }
     }
 
+    checkScoverage {
+        onlyIf { project.name.endsWith('-tests') }
+    }
+
 }
 
 configure(subprojects.findAll { it.name.endsWith('-tests') }) {


### PR DESCRIPTION
I have some things still to check - 
- [ ] verify the relationship between the published artifact configuration 'scoverage' and the dependency configuration 'scoverage'
- [ ] provide a simpler way to create the dependency between a and a-tests
- [x] find out where the closeTo matcher can be found so that we can continue using the assertThat syntax 
